### PR TITLE
Adjust buildkite agent queue max size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/.terraform/*
 
 # .tfstate files
-*.tfstate
+*/infra/aws/remote-state/*.tfstate
 *.tfstate.*
 
 # Crash log files

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/.terraform/*
 
 # .tfstate files
-*/infra/aws/remote-state/*.tfstate
+*.tfstate
 *.tfstate.*
 
 # Crash log files

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -49,7 +49,7 @@ locals {
     small-cpu-queue = {
       BuildkiteQueue          = "small_cpu_queue"
       InstanceTypes           = "r6in.large" # r6in uses Intel Ice Lake which supports AVX-512 required by vLLM CPU backend.
-      MaxSize                 = 2
+      MaxSize                 = 1
       ECRAccessPolicy         = "poweruser"
       InstanceOperatingSystem = "linux"
       OnDemandPercentage      = 100
@@ -58,7 +58,7 @@ locals {
     cpu-queue = {
       BuildkiteQueue          = "cpu_queue"
       InstanceTypes           = "r6in.16xlarge" # r6in uses Intel Ice Lake which supports AVX-512 required by vLLM CPU backend. 16x large comes with 512GB memory, required for compiling CUDA kernel.
-      MaxSize                 = 2
+      MaxSize                 = 5
       ECRAccessPolicy         = "poweruser"
       InstanceOperatingSystem = "linux"
       OnDemandPercentage      = 100
@@ -68,7 +68,7 @@ locals {
     gpu-1-queue = {
       BuildkiteQueue          = "gpu_1_queue" # Queue for jobs running on 1 GPU
       InstanceTypes           = "g6.4xlarge"  # 1 Nvidia L4 GPU and 64GB memory.
-      MaxSize                 = 60
+      MaxSize                 = 80
       ECRAccessPolicy         = "readonly"
       InstanceOperatingSystem = "linux"
       OnDemandPercentage      = 100
@@ -78,7 +78,7 @@ locals {
     gpu-4-queue = {
       BuildkiteQueue          = "gpu_4_queue" # Queue for jobs running on 4 GPUs
       InstanceTypes           = "g6.12xlarge" # 4 Nvidia L4 GPUs and 192GB memory.
-      MaxSize                 = 4
+      MaxSize                 = 10
       ECRAccessPolicy         = "readonly"
       InstanceOperatingSystem = "linux"
       OnDemandPercentage      = 100

--- a/infra/aws/remote-state/terraform.tfstate
+++ b/infra/aws/remote-state/terraform.tfstate
@@ -203,3 +203,4 @@
   ],
   "check_results": null
 }
+

--- a/infra/aws/remote-state/terraform.tfstate
+++ b/infra/aws/remote-state/terraform.tfstate
@@ -1,0 +1,205 @@
+{
+  "version": 4,
+  "terraform_version": "1.7.4",
+  "serial": 5,
+  "lineage": "67953afd-fcc9-a235-a809-cc76f79c2125",
+  "outputs": {
+    "bucket": {
+      "value": "vllm-aws-ci-infra-tfstate-73a29571ae23e9cb",
+      "type": "string"
+    },
+    "dynamodb_table": {
+      "value": "terraform-state-lock",
+      "type": "string"
+    },
+    "key": {
+      "value": "terraform.tfstate",
+      "type": "string"
+    },
+    "region": {
+      "value": "us-west-2",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_dynamodb_table",
+      "name": "state_lock_table",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:dynamodb:us-west-2:936637512419:table/terraform-state-lock",
+            "attribute": [
+              {
+                "name": "LockID",
+                "type": "S"
+              }
+            ],
+            "billing_mode": "PAY_PER_REQUEST",
+            "deletion_protection_enabled": false,
+            "global_secondary_index": [],
+            "hash_key": "LockID",
+            "id": "terraform-state-lock",
+            "import_table": [],
+            "local_secondary_index": [],
+            "name": "terraform-state-lock",
+            "point_in_time_recovery": [
+              {
+                "enabled": true
+              }
+            ],
+            "range_key": null,
+            "read_capacity": 0,
+            "replica": [],
+            "restore_date_time": null,
+            "restore_source_name": null,
+            "restore_to_latest_time": null,
+            "server_side_encryption": [],
+            "stream_arn": "",
+            "stream_enabled": false,
+            "stream_label": "",
+            "stream_view_type": "",
+            "table_class": "STANDARD",
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null,
+            "ttl": [
+              {
+                "attribute_name": "",
+                "enabled": false
+              }
+            ],
+            "write_capacity": 0
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxODAwMDAwMDAwMDAwLCJkZWxldGUiOjYwMDAwMDAwMDAwMCwidXBkYXRlIjozNjAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "state_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::vllm-aws-ci-infra-tfstate-73a29571ae23e9cb",
+            "bucket": "vllm-aws-ci-infra-tfstate-73a29571ae23e9cb",
+            "bucket_domain_name": "vllm-aws-ci-infra-tfstate-73a29571ae23e9cb.s3.amazonaws.com",
+            "bucket_prefix": "",
+            "bucket_regional_domain_name": "vllm-aws-ci-infra-tfstate-73a29571ae23e9cb.s3.us-west-2.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": null,
+            "grant": [
+              {
+                "id": "03a117e2a15198e98f224a50154b459577622e195f9a8eb3b1416e1862c073ea",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3BJ6K6RIION7M",
+            "id": "vllm-aws-ci-infra-tfstate-73a29571ae23e9cb",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-west-2",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": true,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMCJ9",
+          "dependencies": [
+            "random_id.name_suffix"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "state_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "vllm-aws-ci-infra-tfstate-73a29571ae23e9cb",
+            "id": "vllm-aws-ci-infra-tfstate-73a29571ae23e9cb",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ==",
+          "dependencies": [
+            "aws_s3_bucket.state_bucket",
+            "random_id.name_suffix"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "random_id",
+      "name": "name_suffix",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "b64_std": "c6KVca4j6cs=",
+            "b64_url": "c6KVca4j6cs",
+            "byte_length": 8,
+            "dec": "8332386576074271179",
+            "hex": "73a29571ae23e9cb",
+            "id": "c6KVca4j6cs",
+            "keepers": null,
+            "prefix": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}


### PR DESCRIPTION
Already applied via terraform. This is to note down the changes on codebase.

- Change `small_cpu_queue` max size to 1 (we are going to have 1 instance running all the time)
- `cpu_queue` from 2 -> 5 
- `gpu_1_queue` from 60 -> 80
- `gpu_4_queue` from 4 -> 10 
