### PR TITLE
Script to bootstrap CI AWS pipeline

### DIFF
--- a/scripts/ci_aws_bootstrap.sh
+++ b/scripts/ci_aws_bootstrap.sh
@@ -45,6 +45,8 @@ if [[ TRIGGER -eq 1 ]]; then
     exit 0
 fi
 
+echo "Uploading pipeline..."
+
 ls .buildkite || buildkite-agent annotate --style error 'Please merge upstream main branch for buildkite CI'
 curl -sSfL https://github.com/mitsuhiko/minijinja/releases/latest/download/minijinja-cli-installer.sh | sh
 source /var/lib/buildkite-agent/.cargo/env

--- a/scripts/ci_aws_bootstrap.sh
+++ b/scripts/ci_aws_bootstrap.sh
@@ -45,6 +45,8 @@ if [[ TRIGGER -eq 1 ]]; then
     exit 0
 fi
 
+exit 0
+
 echo "Uploading pipeline..."
 
 ls .buildkite || buildkite-agent annotate --style error 'Please merge upstream main branch for buildkite CI'

--- a/scripts/ci_aws_bootstrap.sh
+++ b/scripts/ci_aws_bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euox pipefail
 
 TRIGGER=0
 

--- a/scripts/ci_aws_bootstrap.sh
+++ b/scripts/ci_aws_bootstrap.sh
@@ -40,18 +40,18 @@ if [[ TRIGGER -eq 1 ]]; then
     done
 fi
 
-if [[ TRIGGER -eq 1 ]]; then
+if [[ TRIGGER -ne 1 ]]; then
     echo "No relevant changes found to trigger tests."
     exit 0
 fi
 
-exit 0
+if [[ TRIGGER -eq 1 ]]; then
+    echo "Uploading pipeline..."
 
-echo "Uploading pipeline..."
-
-ls .buildkite || buildkite-agent annotate --style error 'Please merge upstream main branch for buildkite CI'
-curl -sSfL https://github.com/mitsuhiko/minijinja/releases/latest/download/minijinja-cli-installer.sh | sh
-source /var/lib/buildkite-agent/.cargo/env
-cd .buildkite && minijinja-cli test-template-aws.j2 test-pipeline.yaml > pipeline.yml
-cat pipeline.yml
-buildkite-agent pipeline upload pipeline.yml
+    ls .buildkite || buildkite-agent annotate --style error 'Please merge upstream main branch for buildkite CI'
+    curl -sSfL https://github.com/mitsuhiko/minijinja/releases/latest/download/minijinja-cli-installer.sh | sh
+    source /var/lib/buildkite-agent/.cargo/env
+    cd .buildkite && minijinja-cli test-template-aws.j2 test-pipeline.yaml > pipeline.yml
+    cat pipeline.yml
+    buildkite-agent pipeline upload pipeline.yml
+fi

--- a/scripts/ci_aws_bootstrap.sh
+++ b/scripts/ci_aws_bootstrap.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TRIGGER=0
+
+if [[ "${BUILDKITE_BRANCH}" == "main" ]]; then
+    echo "Run full tests on main"
+    TRIGGER=1
+fi
+
+get_diff() {
+    echo $(git diff --name-only --diff-filter=ACM $(git merge-base origin/main HEAD))
+}
+
+if [[ TRIGGER -eq 1 ]]; then
+    diff=$(get_diff)
+
+    patterns=(
+        ".buildkite/"
+        ".github/"
+        "cmake/"
+        "benchmarks/"
+        "csrc/"
+        "tests/"
+        "vllm/"
+        "Dockerfile"
+        "format.sh"
+        "pyproject.toml"
+        "requirements*"
+        "setup.py"
+    )
+    for file in $diff; do
+        for pattern in "${patterns[@]}"; do
+            if [[ $file == $pattern* ]] || [[ $file == $pattern ]]; then
+                TRIGGER=1
+                break
+            fi
+        done
+    done
+fi
+
+if [[ TRIGGER -eq 1 ]]; then
+    echo "No relevant changes found to trigger tests."
+    exit 0
+fi
+
+ls .buildkite || buildkite-agent annotate --style error 'Please merge upstream main branch for buildkite CI'
+curl -sSfL https://github.com/mitsuhiko/minijinja/releases/latest/download/minijinja-cli-installer.sh | sh
+source /var/lib/buildkite-agent/.cargo/env
+cd .buildkite && minijinja-cli test-template-aws.j2 test-pipeline.yaml > pipeline.yml
+cat pipeline.yml
+buildkite-agent pipeline upload pipeline.yml

--- a/scripts/ci_aws_bootstrap.sh
+++ b/scripts/ci_aws_bootstrap.sh
@@ -13,7 +13,7 @@ get_diff() {
     echo $(git diff --name-only --diff-filter=ACM $(git merge-base origin/main HEAD))
 }
 
-if [[ TRIGGER -eq 1 ]]; then
+if [[ TRIGGER -ne 1 ]]; then
     diff=$(get_diff)
 
     patterns=(

--- a/scripts/ci_aws_bootstrap.sh
+++ b/scripts/ci_aws_bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euox pipefail
+set -euo pipefail
 
 TRIGGER=0
 


### PR DESCRIPTION
- Always trigger tests if it's on `main` branch
- Check if ACM files matched with one of the patterns to trigger tests.
- Otherwise, skip uploading pipeline and exit 0.