### PR TITLE
Update AMD tests delimiter

### DIFF
--- a/scripts/test-template-aws.j2
+++ b/scripts/test-template-aws.j2
@@ -27,7 +27,7 @@ steps:
       - label: "AMD: {{ step.label }}"
         agents:
           queue: amd
-        command: bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
+        command: bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" && ")) | safe }}"
         env:
           DOCKER_BUILDKIT: "1"
         priority: 100


### PR DESCRIPTION
Not really sure how changes here should go, apologies if this repo shouldn't be PR-ed to.

In this PR: https://github.com/vllm-project/vllm/pull/5422 I've corrected how AMD tests should be launched: the current method is problematic because only the exit code for the last test is captured, so a test stage might be marked as passing just because the last one passes, even though intermediate ones fail.

However, I noticed that this change is no longer being reflected in the tests, even though it was a few days ago. Also, an Intel test that is not in my repo is still being run. It seems that the vLLM CI now obeys `vllm-project/buildkite-ci/scripts/test-template-aws.j2` instead of the one at `vllm-project/vllm/blob/main/.buildkite/test-template-aws.j2`:

`curl -sSL https://raw.githubusercontent.com/vllm-project/buildkite-ci/main/scripts/ci_aws_bootstrap.sh | bash`
and inside `scripts/ci_aws_bootstrap.sh`,
`curl -o .buildkite/test-template.j2 https://raw.githubusercontent.com/vllm-project/buildkite-ci/main/scripts/test-template-aws.j2`

The offending commit appears to be https://github.com/vllm-project/buildkite-ci/commit/07073a914f3e35c735993a568f9dc45cbd5a4c37

It appears that this repo is updated manually when changes are detected in `vllm-project/vllm/blob/main/.buildkite/test-template-aws.j2`, which doesn't seem very portable and desyncs some CI changes from the CI for that PR (which can be good and/or bad).