### PR TITLE
Mount HF Cache on A100

### DIFF
--- a/scripts/test-template-aws.j2
+++ b/scripts/test-template-aws.j2
@@ -157,7 +157,6 @@ steps:
           - name: devshm
             emptyDir:
               medium: Memory
-          - name: hf-cache
-            emptyDir: {}
+          - {{ hf_home }}:{{ hf_home }}
   {% endif %}
   {% endfor %}


### PR DESCRIPTION
SUMMARY:
* A100 tests need access to hf-cache
* This PR attempts to actually mount the cache properly