### PR TITLE
Fix apt install bug

### DIFF
--- a/scripts/kickoff-benchmark.sh
+++ b/scripts/kickoff-benchmark.sh
@@ -3,13 +3,6 @@
 # NOTE(simon): this script runs inside a buildkite agent with CPU only access.
 set -euo pipefail
 
-# Install system packages
-apt update
-apt install -y curl jq
-
-# Install minijinja for templating
-curl -sSfL https://github.com/mitsuhiko/minijinja/releases/latest/download/minijinja-cli-installer.sh | sh
-source $HOME/.cargo/env
 target_yaml_file=""
 
 # If BUILDKITE_PULL_REQUEST != "false", then we check the PR labels using curl and jq


### PR DESCRIPTION
The current CI triggers an error:
![image](https://github.com/vllm-project/buildkite-ci/assets/16879550/9a4d565d-9dae-4720-946f-148b0546af63)
So I remove the line `apt install xxxxx`.