### PR TITLE
AMD build circumvents wait

### DIFF
--- a/scripts/test-template-aws.j2
+++ b/scripts/test-template-aws.j2
@@ -23,9 +23,9 @@ steps:
   - wait
 
   - group: "AMD Tests"
+    depends_on: ~
     steps:
       - label: "AMD: :docker: build image"
-        depends_on: ~
         commands:
           - "docker build --build-arg max_jobs=16 --tag {{ docker_image_amd }} -f Dockerfile.rocm --progress plain ."
           - "docker push {{ docker_image_amd }}"


### PR DESCRIPTION
Moved depends_on so AMD build happens concurrently with other build step. 