### PR TITLE
Remove Intel tests from fastcheck

### DIFF
--- a/scripts/test-template-fastcheck.j2
+++ b/scripts/test-template-fastcheck.j2
@@ -33,18 +33,6 @@ steps:
     command: bash .buildkite/run-neuron-test.sh
     soft_fail: false
 
-  - label: "Intel CPU Test"
-    depends_on: ~
-    agents:
-      queue: intel-cpu
-    command: bash .buildkite/run-cpu-test.sh
-
-  - label: "Intel GPU Test"
-    depends_on: ~
-    agents:
-      queue: intel-gpu
-    command: bash .buildkite/run-xpu-test.sh
-
   {% for step in steps %}
   {% if step.gpu != "a100" and step.fast_check == true and step.num_nodes < 2 %}
   - label: "{{ step.label }}"


### PR DESCRIPTION
Since there is only one machine to run Intel CPU and GPU tests (each), the queue time can get quite long ([example](https://buildkite.com/vllm/ci-aws/builds/5023)) when they are run for every commit. This PR removes such tests from `fastcheck` so they are only run in the full CI.