### PR TITLE
Fix amd fastcheck

### DIFF
--- a/scripts/test-template-fastcheck.j2
+++ b/scripts/test-template-fastcheck.j2
@@ -1,4 +1,5 @@
 {% set docker_image = "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT" %}
+{% set docker_image_amd = "rocm/vllm-ci:$BUILDKITE_COMMIT" %}
 {% set default_working_dir = "/vllm-workspace/tests" %}
 {% set hf_home = "/root/.cache/huggingface" %}
 


### PR DESCRIPTION
The `docker_image_amd` var is not set :(

See the tag failing to render on this failing build here: https://buildkite.com/vllm/fastcheck/builds/3696#0191bdc8-9e6f-4a25-ba5c-8ca835ed586d