### PR TITLE
Add support for IBM Z (s390x) platform in Buildkite CI

### DIFF
--- a/scripts/test-template-ci.j2
+++ b/scripts/test-template-ci.j2
@@ -325,7 +325,16 @@ steps:
       queue: ibm-ppc64le
     command: bash .buildkite/scripts/hardware_ci/run-cpu-test-ppc64le.sh
   {% endif %}
-
+ 
+  {% if branch == "main" or "s390x" in branch %}
+  - label: "IBM Z (s390x) CPU Test"
+    depends_on: ~
+    soft_fail: true
+    agents:
+      queue: ibm_s390x
+    command: bash .buildkite/scripts/hardware_ci/run-cpu-test-s390x.sh
+  {% endif %}
+ 
   {% if nightly == "1" %}
   - label: "GH200 Test"
     depends_on: ~


### PR DESCRIPTION
### Summary

This PR adds initial support for IBM Z (s390x) platform in Buildkite CI.

### Changes
- Adds a new job to `.buildkite/test-template-ci.j2` that:
  - Targets the `ibm_s390x` queue
  - Runs the script `.buildkite/run-cpu-test-s390x.sh`
  - Is enabled when the branch is `main` or contains `"s390x"`

### Testing
- Successfully tested the job on IBM Z (s390x) community cloud instance by connecting it as a Buildkite agent.  
- Verified the pipeline integration using vLLM's community Buildkite organization (`vllm/ci`).
- Build link: https://buildkite.com/vllm/ci/builds/16786#0195f54e-9d9c-4bed-b3d2-c227db0fc04f

cc @khluu 